### PR TITLE
Fix issue with generated "use strict" directives

### DIFF
--- a/babylon-to-espree/attachComments.js
+++ b/babylon-to-espree/attachComments.js
@@ -53,7 +53,12 @@ module.exports = function (ast, comments, tokens) {
     }
   }
   if (ast.body && ast.body.length > 0) {
-    ast.loc.start.line = ast.body[0].loc.start.line;
-    ast.range[0] = ast.body[0].start;
+    // when reading from a manipulated ast, the loc might not be present for generated nodes
+    // like the "use strict" directive
+    var bodyWithLoc = ast.body.find((b) => b.loc);
+    if (bodyWithLoc) {
+      ast.loc.start.line = bodyWithLoc.loc.start.line;
+      ast.range[0] = bodyWithLoc.start;
+    }
   }
 };


### PR DESCRIPTION
Hi, babel-to-estree is being used by parcel-bundler to convert the javascript ASTs. This AST might have new nodes added by babel plugins, but those nodes have no loc information.
This PR changes the behavior to get the first body item with a loc instead of relying on body[0].